### PR TITLE
[60-1.py] Indentation 오류

### DIFF
--- a/5-algorithms/ch17/60-1.py
+++ b/5-algorithms/ch17/60-1.py
@@ -15,4 +15,4 @@ class Solution:
             cur.next, head.next, head = head, cur.next, head.next
 
             cur = parent
-            return cur.next
+        return cur.next


### PR DESCRIPTION
return cur.next의 indentation 오류입니다. head의 while loop 안에서 1번 처리 후 종료됩니다.